### PR TITLE
Refactor results flattening and handle top level `Result`s

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TestReports"
 uuid = "dcd651b4-b50a-5b6b-8f22-87e9f253a252"
-version = "0.2.6"
+version = "0.3.0"
 
 [deps]
 EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"

--- a/test/references/complexexample.txt
+++ b/test/references/complexexample.txt
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="Example/Math" id="_id_" tests="13" failures="4" errors="3"><testsuite name="Multiplication" id="_id_" tests="3" failures="1" errors="0"><testcase name="pass (info lost)" id="_testcase_id_"/><testcase name="1 * 2 == 5" id="_testcase_id_"><failure message="2 == 5" type="test">Test Failed
+<testsuites name="Example" id="_id_" tests="13" failures="4" errors="3"><testsuite name="Math/Multiplication" id="_id_" tests="3" failures="1" errors="0"><testcase name="pass (info lost)" id="_testcase_id_"/><testcase name="1 * 2 == 5" id="_testcase_id_"><failure message="2 == 5" type="test">Test Failed
   Expression: 1 * 2 == 5
-   Evaluated: 2 == 5</failure></testcase><testcase name="pass (info lost)" id="_testcase_id_"/></testsuite><testsuite name="" id="_id_" tests="1" failures="0" errors="0"><testcase name="pass (info lost)" id="_testcase_id_"/></testsuite><testsuite name="" id="_id_" tests="1" failures="1" errors="0"><testcase name="sqrt(20) == 5" id="_testcase_id_"><failure message="4.47213595499958 == 5" type="test">Test Failed
-  Expression: sqrt(20) == 5
-   Evaluated: 4.47213595499958 == 5</failure></testcase></testsuite><testsuite name="" id="_id_" tests="1" failures="0" errors="0"><testcase name="pass (info lost)" id="_testcase_id_"/></testsuite><testsuite name="addition" id="_id_" tests="3" failures="1" errors="0"><testcase name="pass (info lost)" id="_testcase_id_"/><testcase name="1 + 2 == 5" id="_testcase_id_"><failure message="3 == 5" type="test">Test Failed
-  Expression: 1 + 2 == 5
-   Evaluated: 3 == 5</failure></testcase><testcase name="pass (info lost)" id="_testcase_id_"/></testsuite><testsuite name="addition/negative addition" id="_id_" tests="3" failures="1" errors="0"><testcase name="pass (info lost)" id="_testcase_id_"/><testcase name="1 + -2 == 1" id="_testcase_id_"><failure message="-1 == 1" type="test">Test Failed
+   Evaluated: 2 == 5</failure></testcase><testcase name="pass (info lost)" id="_testcase_id_"/></testsuite><testsuite name="Math/addition/negative addition" id="_id_" tests="3" failures="1" errors="0"><testcase name="pass (info lost)" id="_testcase_id_"/><testcase name="1 + -2 == 1" id="_testcase_id_"><failure message="-1 == 1" type="test">Test Failed
   Expression: 1 + -2 == 1
-   Evaluated: -1 == 1</failure></testcase><testcase name="pass (info lost)" id="_testcase_id_"/></testsuite><testsuite name="other" id="_id_" tests="0" failures="0" errors="3"><testcase name="sqrt(-1)" id="_testcase_id_"><skip/></testcase><error message="Inf" type="String">
+   Evaluated: -1 == 1</failure></testcase><testcase name="pass (info lost)" id="_testcase_id_"/></testsuite><testsuite name="Math/addition" id="_id_" tests="3" failures="1" errors="0"><testcase name="pass (info lost)" id="_testcase_id_"/><testcase name="1 + 2 == 5" id="_testcase_id_"><failure message="3 == 5" type="test">Test Failed
+  Expression: 1 + 2 == 5
+   Evaluated: 3 == 5</failure></testcase><testcase name="pass (info lost)" id="_testcase_id_"/></testsuite><testsuite name="Math/other" id="_id_" tests="0" failures="0" errors="3"><testcase name="sqrt(-1)" id="_testcase_id_"><skip/></testcase><error message="Inf" type="String">
 </error><error message="ErrorException(&quot;Nooo&quot;)" type="String">
 </error><error message="DimensionMismatch(&quot;B has leading dimension 4, but needs 2&quot;)" type="String">
-</error></testsuite><testsuite name="using function from a module" id="_id_" tests="1" failures="0" errors="0"><testcase name="pass (info lost)" id="_testcase_id_"/></testsuite></testsuites>
+</error></testsuite><testsuite name="Math/using function from a module" id="_id_" tests="1" failures="0" errors="0"><testcase name="pass (info lost)" id="_testcase_id_"/></testsuite><testsuite name="Math" id="_id_" tests="3" failures="1" errors="0"><testcase name="pass (info lost)" id="_testcase_id_"/><testcase name="sqrt(20) == 5" id="_testcase_id_"><failure message="4.47213595499958 == 5" type="test">Test Failed
+  Expression: sqrt(20) == 5
+   Evaluated: 4.47213595499958 == 5</failure></testcase><testcase name="pass (info lost)" id="_testcase_id_"/></testsuite></testsuites>
 

--- a/test/references/singlenest.txt
+++ b/test/references/singlenest.txt
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="blah/a" id="_id_" tests="1" failures="0" errors="0"><testsuite name="" id="_id_" tests="1" failures="0" errors="0"><testcase name="pass (info lost)" id="_testcase_id_"/></testsuite></testsuites>
+<testsuites name="blah" id="_id_" tests="1" failures="0" errors="0"><testsuite name="a" id="_id_" tests="1" failures="0" errors="0"><testcase name="pass (info lost)" id="_testcase_id_"/></testsuite></testsuites>

--- a/test/testsets.jl
+++ b/test/testsets.jl
@@ -1,0 +1,157 @@
+using Test
+import Test: finish, record, AbstractTestSet, Result, get_testset_depth, get_testset,
+    Pass, Fail, Broken, Error
+using TestReports
+
+mutable struct NoFlattenRecordingTestSet <: AbstractTestSet
+    description::AbstractString
+    results::Vector
+end
+NoFlattenRecordingTestSet(desc) = NoFlattenRecordingTestSet(desc, [])
+record(ts::NoFlattenRecordingTestSet, t) = (push!(ts.results, t); t)
+function finish(ts::NoFlattenRecordingTestSet)
+    if get_testset_depth() != 0
+        # Attach this test set to the parent test set
+        parent_ts = get_testset()
+        record(parent_ts, ts)
+        return ts
+    end
+    return ts
+end
+
+@testset "handle_top_level_results!" begin
+    # Simple top level resuls
+    ts = @testset NoFlattenRecordingTestSet "" begin
+        @test 1 == 1
+        @test 2 == 2
+    end
+
+    TestReports.handle_top_level_results!(ts)
+    @test length(ts.results) == 1
+    @test ts.results[1] isa AbstractTestSet
+    @test length(ts.results[1].results) == 2
+    @test all(isa.(ts.results[1].results, Result))
+
+    # Mix of top level testset and results
+    ts = @testset NoFlattenRecordingTestSet "" begin
+        @test 1 == 1
+        @test 2 == 2
+        @testset "Inner" begin
+            @test 3 == 3
+            @test 4 == 4
+        end
+    end 
+
+    TestReports.handle_top_level_results!(ts)
+    @test length(ts.results) == 2
+    @test all(isa.(ts.results,  AbstractTestSet))
+    @test length(ts.results[1].results) == 2
+    @test all(isa.(ts.results[1].results, Result))
+    @test length(ts.results[2].results) == 2
+    @test all(isa.(ts.results[2].results, Result))
+    @test ts.results[2].description == "Inner"
+
+    # Testset only
+    ts = @testset NoFlattenRecordingTestSet "" begin
+        @testset "Shouldn't Change" begin
+            @test 1 == 1
+            @test 2 == 2
+        end
+    end
+
+    TestReports.handle_top_level_results!(ts)
+    @test length(ts.results) == 1
+    @test ts.results[1].description == "Shouldn't Change"
+end
+
+@testset "_flatten_results!" begin
+    # Single nested test
+    ts = @testset NoFlattenRecordingTestSet "Nested" begin
+        @testset "1" begin
+            @testset "2" begin
+                @testset "3" begin
+                    @test 1 == 1
+                end
+            end
+        end
+    end
+    flattened_results = TestReports._flatten_results!(ts)
+    @test length(flattened_results) == 1
+    @test flattened_results[1] isa AbstractTestSet
+    @test flattened_results[1].description == "Nested/1/2/3"
+
+    # Different level nested tests
+    ts = @testset NoFlattenRecordingTestSet "Nested" begin
+        @testset "1" begin
+            @testset "2" begin
+                @testset "3" begin
+                    @test 1 == 1
+                end
+                @test 2 == 2
+            end
+        end
+    end
+    flattened_results = TestReports._flatten_results!(ts)
+    @test length(flattened_results) == 2
+    @test all(isa.(flattened_results, AbstractTestSet))
+    @test flattened_results[1].description == "Nested/1/2/3"
+    @test flattened_results[2].description == "Nested/1/2"
+end
+
+@testset "ReportingTestSet Display" begin
+    # Test adding of results
+    ts_default = Test.DefaultTestSet("")
+    TestReports.add_to_ts_default!(ts_default, Test.Pass(:null, nothing, nothing, nothing))
+    @test length(ts_default.results) == 0
+    @test ts_default.n_passed == 1
+    TestReports.add_to_ts_default!(ts_default, Test.Fail(:null,:(1==2),nothing,nothing,LineNumberNode(1)))
+    @test ts_default.n_passed == 1
+    @test typeof(ts_default.results[1]) == Test.Fail
+    TestReports.add_to_ts_default!(ts_default, Test.Error(:null,:(1==2),nothing,nothing,LineNumberNode(1)))
+    @test ts_default.n_passed == 1
+    @test typeof(ts_default.results[2]) == Test.Error
+
+    # Test adding of test set
+    ts_reporting = ReportingTestSet("rts")
+    Test.record(ts_reporting, Test.Pass(:null, nothing, nothing, nothing))
+    TestReports.add_to_ts_default!(ts_default, ts_reporting)
+    @test typeof(ts_default.results[3]) == Test.DefaultTestSet
+
+    # Test displaying of results doesn't change reporting test set
+    ts_reporting_copy = deepcopy(ts_reporting)
+    @test TestReports.display_reporting_testset(ts_reporting) == nothing
+    @test ts_reporting_copy.results == ts_reporting.results
+
+    # Test fail/error in results doesn't throw error
+    Test.record(ts_reporting, Fail(Symbol(), 1, "1", "1", LineNumberNode(1)))
+    @test TestReports.display_reporting_testset(ts_reporting) == nothing
+end
+
+@testset "any_problems" begin
+    @test any_problems(Pass(Symbol(), nothing, nothing, nothing)) == false
+    @test any_problems(Fail(Symbol(), nothing, nothing, nothing, LineNumberNode(1))) == true
+    @test any_problems(Broken(Symbol(1), nothing)) == false
+    @test any_problems(Error(Symbol(), nothing, nothing, nothing, LineNumberNode(1))) == true
+
+    fail_code = """
+    using Test
+    using TestReports
+    ts = @testset ReportingTestSet "eg" begin
+        @test false == true
+    end;
+    exit(any_problems(ts))
+    """
+
+    @test_throws Exception run(`$(Base.julia_cmd()) -e $(fail_code)`)
+
+    pass_code = """
+    using Test
+    using TestReports
+    ts = @testset ReportingTestSet "eg" begin
+        @test true == true
+    end;
+    exit(any_problems(ts))
+    """
+
+    @test run(`$(Base.julia_cmd()) -e $(pass_code)`) isa Any #this line would error if fail
+end


### PR DESCRIPTION
Closes #26 

### Summary
If a packages `runtests.jl` contains tests that are not in a `TestSet`, they are now added to a test set so that in the report they are included in the same testsuite element. This also helps the displaying of the results to look more like `Pkg.test`.

Additionally, the changes work when `runtests.jl` contains a single nested test set, as per #26. See Example 3 below.

Changes in more depth:

- `flatten_results!` now deals with top level results using `handle_top_level_results!`
- `_flatten_results!` now doesn't need second argument, as it is never passed results at the top level
- `_flatten_results!` slightly changed so that the singleton logic is not needed in `flatten_results!`
- test set tests moved to own script
- set to version 0.3.0 as this may change the xml and is therefore breaking

### Things to discuss

Should `flatten_results!` happen in `finish` or when producing the report? As it outputs a format specifically for reporting I'm inclined to think it should be in the writing of the report. Doesn't matter too much if most people are using `TestReports.test()` I guess.

### Examples
1) If `runtests.jl` contains
```Julia
using Test

@test 1 == 1
@test 2 == 2
```

The xml now looks like
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites name="" id="_id_" tests="2" failures="0" errors="0">
    <testsuite name="Top level tests" id="_id_" tests="2" failures="0" errors="0">
        <testcase name="pass (info lost)" id="_testcase_id_"/>
        <testcase name="pass (info lost)" id="_testcase_id_"/>
    </testsuite>
</testsuites>
```
Rather than:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites name="" id="_id_" tests="2" failures="0" errors="0">
    <testsuite name="" id="_id_" tests="1" failures="0" errors="0">
        <testcase name="pass (info lost)" id="_testcase_id_"/>
    </testsuite>
    <testsuite name="" id="_id_" tests="1" failures="0" errors="0">
        <testcase name="pass (info lost)" id="_testcase_id_"/>
    </testsuite>
</testsuites>

```
And the following is displayed
```
Test Summary:   | Pass  Total
Top level tests |    2      2
```
Rather than
```
Test Summary: | Pass  Total
              |    1      1
Test Summary: | Pass  Total
              |    1      1
```
2) If `runtests.jl` contains
```Julia
using Test

@test 1 == 1
@test 2 == 2
@testset "MyTests" begin
        @test 3==3
end
```
The xml now looks like
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites name="" id="_id_" tests="3" failures="0" errors="0">
    <testsuite name="Top level tests" id="_id_" tests="2" failures="0" errors="0">
        <testcase name="pass (info lost)" id="_testcase_id_"/>
        <testcase name="pass (info lost)" id="_testcase_id_"/>
    </testsuite>
    <testsuite name="MyTests" id="_id_" tests="1" failures="0" errors="0">
        <testcase name="pass (info lost)" id="_testcase_id_"/>
    </testsuite>
</testsuites>

```
Rather than
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites name="" id="_id_" tests="3" failures="0" errors="0">
    <testsuite name="" id="_id_" tests="1" failures="0" errors="0">
        <testcase name="pass (info lost)" id="_testcase_id_"/>
    </testsuite>
    <testsuite name="" id="_id_" tests="1" failures="0" errors="0">
        <testcase name="pass (info lost)" id="_testcase_id_"/>
    </testsuite>
    <testsuite name="MyTests" id="_id_" tests="1" failures="0" errors="0">
        <testcase name="pass (info lost)" id="_testcase_id_"/>
    </testsuite>
</testsuites>
```
And the following is displayed
```
Test Summary:   | Pass  Total
Top level tests |    2      2
Test Summary: | Pass  Total
MyTests       |    1      1
```
Rather than
```
Test Summary: | Pass  Total
              |    1      1
Test Summary: | Pass  Total
              |    1      1
Test Summary: | Pass  Total
MyTests       |    1      1
```
3) If `runtests.jl` contains
```Julia
using Test

@testset "MyTests" begin
    @test 1 == 1
    @test 2 == 2
end
```
The xml now looks like
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites name="" id="_id_" tests="2" failures="0" errors="0">
    <testsuite name="MyTests" id="_id_" tests="2" failures="0" errors="0">
        <testcase name="pass (info lost)" id="_testcase_id_"/>
        <testcase name="pass (info lost)" id="_testcase_id_"/>
    </testsuite>
</testsuites>
```
Rather than
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites name="/MyTests" id="_id_" tests="2" failures="0" errors="0">
    <testsuite name="" id="_id_" tests="1" failures="0" errors="0">
        <testcase name="pass (info lost)" id="_testcase_id_"/>
    </testsuite>
    <testsuite name="" id="_id_" tests="1" failures="0" errors="0">
        <testcase name="pass (info lost)" id="_testcase_id_"/>
    </testsuite>
</testsuites>
```
And the following is displayed
```
Test Summary: | Pass  Total
MyTests       |    2      2
```
Rather than
```
Test Summary: | Pass  Total
              |    1      1
Test Summary: | Pass  Total
              |    1      1
```