### PR TITLE
Make ReportingTestSet behaviour consistent

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TestReports"
 uuid = "dcd651b4-b50a-5b6b-8f22-87e9f253a252"
-version = "0.3.3"
+version = "0.4.0"
 
 [deps]
 EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"

--- a/bin/reporttests.jl
+++ b/bin/reporttests.jl
@@ -11,8 +11,6 @@ ts = @testset ReportingTestSet "" begin
     include($(repr(testfilename)))
 end
 
-display_reporting_testset(ts)
-
 open("testlog.xml","w") do fh
     print(fh, report(ts))
 end

--- a/src/TestReports.jl
+++ b/src/TestReports.jl
@@ -7,8 +7,7 @@ using EzXML
 import Test: AbstractTestSet, DefaultTestSet, record, finish, get_testset_depth, get_testset
 import Test: Result, Fail, Broken, Pass, Error, scrub_backtrace
 
-export ReportingTestSet, any_problems, report, display_reporting_testset,
-    recordproperty
+export ReportingTestSet, any_problems, report, recordproperty
 
 include("./testsets.jl")
 include("to_xml.jl")

--- a/src/runner.jl
+++ b/src/runner.jl
@@ -16,8 +16,6 @@ function gen_runner_code(testfilename, logfilename, testreportsdir, test_args)
         include($(repr(testfilename)))
     end
 
-    display_reporting_testset(ts)
-
     write($(repr(logfilename)), report(ts))
     any_problems(ts) && exit(TestReports.TESTS_FAILED)
     """

--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -1,4 +1,25 @@
+"""
+    ReportingTestSet
 
+Custom `AbstractTestSet` type designed to be used by `TestReports.jl` for
+creation of JUnit XMLs.
+
+Does not throw an error when a test fails or has an error. Upon `finish`ing,
+a `ReportingTestSet` will display the default test output, and then flatten
+to a structure that is suitable for report generation.
+
+It is designed to be wrapped around a package's `runtests.jl` file and this
+is assumed when both the test results are displayed and when the `TestSet` is
+flatted upon `finish`. See `bin/reporttests.jl` for an example of this use.
+`ReportingTestSet`s are not designed to be used directly in a package's tests,
+and this is not recommended or supported.
+
+A `ReportingTestSet` has the `description` and `results` fields as per a
+`DefaultTestSet`, and has an additional `properties` field which is used
+to record properties to be inserted into the report.
+
+See also: [`flatten_results!`](@ref), [`recordproperty`](@ref), [`report`](@ref)
+"""
 mutable struct ReportingTestSet <: AbstractTestSet
     description::String
     results::Vector
@@ -18,6 +39,9 @@ function finish(ts::ReportingTestSet)
         record(parent_ts, ts)
         return ts
     end
+
+    # Display before flattening to match Pkg.test output
+    display_reporting_testset(ts)
 
     # We are the top level, lets do this
     flatten_results!(ts)

--- a/src/to_xml.jl
+++ b/src/to_xml.jl
@@ -120,6 +120,7 @@ That is, the results of the top level `TestSet` must all be `AbstractTestSet`s,
 and the results of those `TestSet`s must all be `Results`.
 """
 function report(ts::AbstractTestSet)
+    check_ts_structure(ts)
     total_ntests = 0
     total_nfails = 0
     total_nerrors = 0
@@ -140,6 +141,20 @@ function report(ts::AbstractTestSet)
                                          x_testsuites))
     
     xdoc
+end
+
+"""
+    check_ts_structure(ts::AbstractTestSet)
+
+Throws an exception if `ts` does not have the right structure for `report`.
+
+See also: [`report`](@ref)
+"""
+function check_ts_structure(ts::AbstractTestSet)
+    !all(isa.(ts.results, AbstractTestSet)) && throw(ArgumentError("Results of ts must all be AbstractTestSets. See documentation for `report`."))
+    for result in ts.results
+        !all(isa.(result.results, Result)) && throw(ArgumentError("Results of each AbstractTestSet in ts.results must all be Results. See documentation for `report`."))
+    end
 end
 
 """

--- a/test/recordproperty.jl
+++ b/test/recordproperty.jl
@@ -87,7 +87,7 @@ end
             TestReports.test(pkg)
         end
         logfile = joinpath(@__DIR__, "testlog.xml")
-        @test_reference "references/test_with_properties.txt" open(f->read(f, String), logfile) |> clean_report
+        @test_reference "references/test_with_properties.txt" open(f->read(f, String), logfile) |> clean_output
     end
 
     # Test for warning when ID set twice

--- a/test/testsets.jl
+++ b/test/testsets.jl
@@ -1,23 +1,6 @@
 using Test
-import Test: finish, record, AbstractTestSet, Result, get_testset_depth, get_testset,
-    Pass, Fail, Broken, Error
+import Test: AbstractTestSet, Result, Pass, Fail, Broken, Error
 using TestReports
-
-mutable struct NoFlattenReportingTestSet <: AbstractTestSet
-    description::AbstractString
-    results::Vector
-end
-NoFlattenReportingTestSet(desc) = NoFlattenReportingTestSet(desc, [])
-record(ts::NoFlattenReportingTestSet, t) = (push!(ts.results, t); t)
-function finish(ts::NoFlattenReportingTestSet)
-    if get_testset_depth() != 0
-        # Attach this test set to the parent test set
-        parent_ts = get_testset()
-        record(parent_ts, ts)
-        return ts
-    end
-    return ts
-end
 
 @testset "handle_top_level_results!" begin
     # Simple top level resuls


### PR DESCRIPTION
@oxinabox please let me know your thoughts on whether this is the right thing to do, I'm in two minds.

I started out moving `display_reporting_testset` to inside of `finish` (closes #34) and realised that both `display_reporting_testset` and `flatten_results` assume that they are being used by something like `TestReports.test`, i.e. that there is an additional `ReportingTestSet` around the tests that are being tested. (As does `report`). This wouldn't be the case if someone was using  a `ReportingTestSet` outside of this (which we don't recommend).

There are two options to make this consistent:

1. Don't export `ReportingTestSet` so that it is private to `TestReports`, which in turn means that `report`,  `display_reporting_testset` and `flatten_results` (the latter two by `finish`) are only used within `TestReports` and therefore doesn't matter what they expect.

2. Do what I've done here, which makes `TestReports.test` add a property to the wrapping `TestSet` which is then checked in `finish`. If the property is not there, an additional wrapping testset is added so that the flattened `ReportingTestSet` will work with `report` in the same way, and the tests will be displayed correctly.

2 gives more flexibility, but I'm not sure if its overkill and opening a can of worms by suggesting people could use `ReportingTestSets` independently. I do, however, like that it will structure any `ReportingTestSet` to be in the correct format for the JUnit XML, and display the results as per `Pkg.test`.

Either way `display_reporting_testset` should be moved inside of `finish` to improve the printing of results.