### PR TITLE
Allow and test for custom TestSets in pkg tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TestReports"
 uuid = "dcd651b4-b50a-5b6b-8f22-87e9f253a252"
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -23,7 +23,7 @@ julia> TestReports.test("MyPackage")
     It is intended that it `runtests.jl` will not need to be changed to generate
     a report (unless [properties are being added](#Adding-Properties)).
     
-    This does assume, however, that `DefaultTestSet`s are being used. In the case of
+    This does assume, however, that no custom `TestSet`s are being used. In the case of
     custom `TestSet`s, please see the [discussion](#Custom-TestSet-Types) below.
 
 The typical use in a CI process would be:
@@ -210,9 +210,20 @@ However at a minimum, for a custom `TestSet` type to work with `TestReports` it 
 - Push itself onto its parent when finishing, if it is not at the top level
 - Have `description` and `results` fields as per a `DefaultTestSet`
 
-Testsuite properties cannot be added to a `TestSet` that is not a `ReportingTestSet`,
-(i.e. any `TestSet` that has the type specified to be something other than a
-`ReportingTestSet`, or that inherits a specified type from a parent). If no types
-are specified, `TestReports.test` will ensure that all child `TestSet`s inherit
-the `ReportingTestSet` type.
+The following information in a JUnit XML relies on the functionality of `ReportingTestSet`s
+but can be added to your own custom `TestSet` as described in the table.
+
+|Information|Description|
+|---|---|
+| testcase time | This is extracted from a `ReportingResult` by the `TestReports.time_taken` function. For standard `Result`s, rather than `ReportingResult`s, this function returns `Dates.Millisecond(0)`. This function can be extended for other custom `Result` types.|
+| testsuite time| This is extracted from a `TestSet` by the `TestReports.time_taken` function, which can be extended for custom `TestSet`s. If not extended, the `AbstractTestSet` method will be used and the value defaults to `Dates.Millisecond(0)`. |
+| testsuite timestamp| This is extracted from a `TestSet` by the `TestReports.start_time` function, which can be extended for custom `TestSet`s. If not extended, the `AbstractTestSet` method will be used and the value defaults to `Dates.now()`. |
+| testsuite hostname| This is extracted from a `TestSet` by the `TestReports.hostname` function, which can be extended for custom `TestSet`s. If not extended, the `AbstractTestSet` method will be used and the value defaults to `gethostname()`. |
+| testsuite properties| This is extracted from a `TestSet` by the `TestReports.properties` function, which can be extended for custom `TestSet`s. If not extended, the `AbstractTestSet` method will be used and the value defaults to `nothing`. |
+
+For further details on extending these fuctions, see the docstrings in [TestSets](@ref).
+
+The [source code of `TestReports`](https://github.com/JuliaTesting/TestReports.jl/blob/master/src/testsets.jl) can be used as a starting point for including this behaviour in your custom `TestSet`s.
+
+If no `TestSet` types are specified (as per the standard `Test` approach), `TestSet` functionality will ensure that all child `TestSet`s inherit the `ReportingTestSet` type.
 

--- a/src/TestReports.jl
+++ b/src/TestReports.jl
@@ -9,6 +9,7 @@ import Test: Result, Fail, Broken, Pass, Error, scrub_backtrace
 
 export ReportingTestSet, any_problems, report, recordproperty
 
+include("v1_compat.jl")
 include("./testsets.jl")
 include("to_xml.jl")
 include("runner.jl")

--- a/src/v1_compat.jl
+++ b/src/v1_compat.jl
@@ -1,0 +1,9 @@
+@static if VERSION < v"1.1.0"
+    """
+        isnothing(x)
+
+    Return `true` if `x === nothing`, and return `false` if not.
+    """
+    isnothing(::Any) = false
+    isnothing(::Nothing) = true
+end

--- a/test/recordproperty.jl
+++ b/test/recordproperty.jl
@@ -111,7 +111,7 @@ using TestReports
             end
         end
         # Force flattening as ts doesn't finish fully as it is not the top level testset
-        fail_text = r"Properties of testset Outer can not be added to child testset Inner as it is not a ReportingTestSet."
+        fail_text = r"Properties of testset Outer can not be added to child testset Inner as it does not have a TestReports.properties method defined."
         @test_logs (:warn, fail_text) TestReports.flatten_results!(ts)
 
         # Test for ReportingTestSet setting a property inside of a parent custom testset
@@ -126,6 +126,11 @@ using TestReports
         # Force flattening as ts doesn't finish fully as it is not the top level testset
         TestReports.flatten_results!(ts)
         @test ts.results[1].properties["ID"] == "42"
+
+        # Error if attempting to add property to AbstractTestSet which has properties field with wrong type
+        ts = @testset WrongPropsTestSet begin; recordproperty("id",1); end
+        @test eval(Meta.parse(ts.results[1].value)) isa TestReports.PkgTestError
+        @test occursin("properties method for custom testset must return a dictionary", eval(Meta.parse(ts.results[1].value)).msg)
     end
 
     @testset "Check no interference with default test set" begin

--- a/test/reportgeneration.jl
+++ b/test/reportgeneration.jl
@@ -149,12 +149,12 @@ end
     @test report(ts) isa Any  # Would fail before #25
 end
 
-@testset "report - check_ts_structure" begin
+@testset "report - check_ts" begin
     # No top level testset
     ts = @testset TestReportingTestSet begin
         @test true
     end
-    @test_throws ArgumentError TestReports.check_ts_structure(ts)
+    @test_throws ArgumentError TestReports.check_ts(ts)
 
     # Not flattened
     ts = @testset TestReportingTestSet begin
@@ -165,7 +165,23 @@ end
             end
         end
     end
-    @test_throws ArgumentError TestReports.check_ts_structure(ts)
+    @test_throws ArgumentError TestReports.check_ts(ts)
+
+    # No description field
+    ts = @testset TestReportingTestSet begin
+        @testset NoDescriptionTestSet begin
+            @test true
+        end
+    end
+    @test_throws ErrorException TestReports.check_ts(ts)
+
+    # No results field
+    ts = @testset TestReportingTestSet begin
+        @testset NoResultsTestSet begin
+            @test true
+        end
+    end
+    @test_throws ErrorException TestReports.check_ts(ts)
 
     # Correct structure
     ts = @testset TestReportingTestSet begin
@@ -173,5 +189,5 @@ end
             @test true
         end
     end
-    @test TestReports.check_ts_structure(ts) isa Any # Doesn't error
+    @test TestReports.check_ts(ts) isa Any # Doesn't error
 end

--- a/test/test_packages/CustomTestSet/Project.toml
+++ b/test/test_packages/CustomTestSet/Project.toml
@@ -1,0 +1,9 @@
+name = "CustomTestSet"
+uuid = "19d8228f-71fc-4fca-a505-eca906948e95"
+version = "0.1.0"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/test_packages/CustomTestSet/src/CustomTestSet.jl
+++ b/test/test_packages/CustomTestSet/src/CustomTestSet.jl
@@ -1,0 +1,5 @@
+module CustomTestSet
+
+greet() = print("Hello World!")
+
+end # module

--- a/test/test_packages/CustomTestSet/test/runtests.jl
+++ b/test/test_packages/CustomTestSet/test/runtests.jl
@@ -1,0 +1,70 @@
+using Test
+import Test: AbstractTestSet, record, finish, get_testset_depth, get_testset
+
+mutable struct MyTestSet <: AbstractTestSet
+    description::String
+    results::Vector
+end
+MyTestSet(desc) = MyTestSet(desc, [])
+record(ts::MyTestSet, t) = (push!(ts.results, t); t)
+function finish(ts::MyTestSet)
+    # If we are a nested test set, do not print a full summary
+    # now - let the parent test set do the printing
+    if get_testset_depth() != 0
+        # Attach this test set to the parent test set
+        parent_ts = get_testset()
+        record(parent_ts, ts)
+        return ts
+    end
+
+    return ts
+end
+
+# Top level tests captured in ReportingTestSet in TestReports
+@test true
+
+# Simple custom TestSet
+@testset MyTestSet "ts1" begin
+    @test true
+end
+
+# More complex custom TestSet
+@testset MyTestSet "ts2" begin
+    @testset MyTestSet "ts3" begin
+        @test true
+    end
+    @test true
+end
+
+# No TestSet specified, should use ReportingTestSet in TestReports
+@testset "ts4" begin
+    @testset "ts5" begin
+        @test true
+    end
+    @test true
+end
+
+# Own time_taken field
+mutable struct TimeTakenTestSet <: AbstractTestSet
+    description::String
+    results::Vector
+    time_taken::Int64
+end
+TimeTakenTestSet(desc) = TimeTakenTestSet(desc, [], -1)
+record(ts::TimeTakenTestSet, t) = (push!(ts.results, t); t)
+function finish(ts::TimeTakenTestSet)
+    # If we are a nested test set, do not print a full summary
+    # now - let the parent test set do the printing
+    if get_testset_depth() != 0
+        # Attach this test set to the parent test set
+        parent_ts = get_testset()
+        record(parent_ts, ts)
+        return ts
+    end
+
+    return ts
+end
+
+@testset TimeTakenTestSet "ts6" begin
+    @test true
+end

--- a/test/test_packages/DefaultTestSet/Project.toml
+++ b/test/test_packages/DefaultTestSet/Project.toml
@@ -1,0 +1,9 @@
+name = "DefaultTestSet"
+uuid = "af5bb637-e1d9-4d89-81d7-b17676f26645"
+version = "0.1.0"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/test_packages/DefaultTestSet/src/DefaultTestSet.jl
+++ b/test/test_packages/DefaultTestSet/src/DefaultTestSet.jl
@@ -1,0 +1,5 @@
+module DefaultTestSet
+
+greet() = print("Hello World!")
+
+end # module

--- a/test/test_packages/DefaultTestSet/test/runtests.jl
+++ b/test/test_packages/DefaultTestSet/test/runtests.jl
@@ -1,0 +1,6 @@
+using Test
+using Test: DefaultTestSet
+
+@testset DefaultTestSet begin
+    @test true
+end

--- a/test/test_packages/NoDescriptionCustomTestSet/Project.toml
+++ b/test/test_packages/NoDescriptionCustomTestSet/Project.toml
@@ -1,0 +1,9 @@
+name = "NoDescriptionCustomTestSet"
+uuid = "19d8228f-71fc-4fca-a505-eca906948e93"
+version = "0.1.0"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/test_packages/NoDescriptionCustomTestSet/src/NoDescriptionCustomTestSet.jl
+++ b/test/test_packages/NoDescriptionCustomTestSet/src/NoDescriptionCustomTestSet.jl
@@ -1,0 +1,5 @@
+module NoDescriptionCustomTestSet
+
+greet() = print("Hello World!")
+
+end # module

--- a/test/test_packages/NoDescriptionCustomTestSet/test/runtests.jl
+++ b/test/test_packages/NoDescriptionCustomTestSet/test/runtests.jl
@@ -1,0 +1,34 @@
+using Test
+import Test: AbstractTestSet, record, finish, get_testset_depth, get_testset
+
+mutable struct NoDescriptionTestSet <: AbstractTestSet
+    results::Vector
+end
+NoDescriptionTestSet(desc) = NoDescriptionTestSet([])
+record(ts::NoDescriptionTestSet, t) = (push!(ts.results, t); t)
+function finish(ts::NoDescriptionTestSet)
+    # If we are a nested test set, do not print a full summary
+    # now - let the parent test set do the printing
+    if get_testset_depth() != 0
+        # Attach this test set to the parent test set
+        parent_ts = get_testset()
+        record(parent_ts, ts)
+        return ts
+    end
+
+    return ts
+end
+
+# Top level tests captured in ReportingTestSet in TestReports
+@test true
+
+# Simple custom TestSet
+@testset NoDescriptionTestSet "ts1" begin
+    @test true
+end
+
+@testset NoDescriptionTestSet "ts1" begin
+    @testset NoDescriptionTestSet "ts1" begin
+        @test true
+    end
+end

--- a/test/test_packages/NoResultsCustomTestSet/Project.toml
+++ b/test/test_packages/NoResultsCustomTestSet/Project.toml
@@ -1,0 +1,9 @@
+name = "NoResultsCustomTestSet"
+uuid = "19d8228f-71fc-4fca-a505-eca906948e94"
+version = "0.1.0"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/test_packages/NoResultsCustomTestSet/src/NoResultsCustomTestSet.jl
+++ b/test/test_packages/NoResultsCustomTestSet/src/NoResultsCustomTestSet.jl
@@ -1,0 +1,5 @@
+module NoResultsCustomTestSet
+
+greet() = print("Hello World!")
+
+end # module

--- a/test/test_packages/NoResultsCustomTestSet/test/runtests.jl
+++ b/test/test_packages/NoResultsCustomTestSet/test/runtests.jl
@@ -1,0 +1,27 @@
+using Test
+import Test: AbstractTestSet, record, finish, get_testset_depth, get_testset
+
+mutable struct NoResultsTestSet <: AbstractTestSet
+    description::String
+end
+record(ts::NoResultsTestSet, t) = t
+function finish(ts::NoResultsTestSet)
+    # If we are a nested test set, do not print a full summary
+    # now - let the parent test set do the printing
+    if get_testset_depth() != 0
+        # Attach this test set to the parent test set
+        parent_ts = get_testset()
+        record(parent_ts, ts)
+        return ts
+    end
+
+    return ts
+end
+
+# Top level tests captured in ReportingTestSet in TestReports
+@test true
+
+# Simple custom TestSet
+@testset NoResultsTestSet "ts1" begin
+    @test true
+end

--- a/test/testsets.jl
+++ b/test/testsets.jl
@@ -179,3 +179,10 @@ end
     @test res1 != res2
     @test hash(res1) != hash(res2)
 end
+
+@testset "Custom testsets" begin
+    test_active_package_expected_pass("DefaultTestSet") # Tests all abstract methods for accessing testset fields
+    test_active_package_expected_pass("CustomTestSet")
+    test_active_package_expected_fail("NoResultsCustomTestSet")
+    test_active_package_expected_fail("NoDescriptionCustomTestSet")
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -218,3 +218,59 @@ function finish(ts::TestReportingTestSet)
     end
     return ts
 end
+
+mutable struct NoDescriptionTestSet <: AbstractTestSet
+    results::Vector
+end
+NoDescriptionTestSet(desc) = NoDescriptionTestSet([])
+record(ts::NoDescriptionTestSet, t) = (push!(ts.results, t); t)
+function finish(ts::NoDescriptionTestSet)
+    # If we are a nested test set, do not print a full summary
+    # now - let the parent test set do the printing
+    if get_testset_depth() != 0
+        # Attach this test set to the parent test set
+        parent_ts = get_testset()
+        record(parent_ts, ts)
+        return ts
+    end
+
+    return ts
+end
+
+mutable struct NoResultsTestSet <: AbstractTestSet
+    description::String
+end
+record(ts::NoResultsTestSet, t) = t
+function finish(ts::NoResultsTestSet)
+    # If we are a nested test set, do not print a full summary
+    # now - let the parent test set do the printing
+    if get_testset_depth() != 0
+        # Attach this test set to the parent test set
+        parent_ts = get_testset()
+        record(parent_ts, ts)
+        return ts
+    end
+
+    return ts
+end
+
+mutable struct WrongPropsTestSet <: AbstractTestSet
+    description::String
+    results::Vector
+    properties::String
+end
+WrongPropsTestSet(desc) = WrongPropsTestSet(desc, [], "")
+record(ts::WrongPropsTestSet, t) = (push!(ts.results, t); t)
+function finish(ts::WrongPropsTestSet)
+    # If we are a nested test set, do not print a full summary
+    # now - let the parent test set do the printing
+    if get_testset_depth() != 0
+        # Attach this test set to the parent test set
+        parent_ts = get_testset()
+        record(parent_ts, ts)
+        return ts
+    end
+
+    return ts
+end
+TestReports.properties(ts::WrongPropsTestSet) = ts.properties


### PR DESCRIPTION
The changes here mean that if a custom `TestSet` has any of the fields `properties`, `time_taken`, `start_time` or `hostname` then they are used in the report. This could break/be strange if these fields are in the test set but used for other things and not what we use them for. Is it better to only populate these values in a report when `ReportingTestSet`s are used or to keep the flexibility for custom `TestSet`s?

Closes #61