### PR TITLE
Update version check for manifest changes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TestReports"
 uuid = "dcd651b4-b50a-5b6b-8f22-87e9f253a252"
-version = "0.6.2"
+version = "0.6.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/compat_check.jl
+++ b/src/compat_check.jl
@@ -73,7 +73,7 @@ end
 Manifest structure changes with Julia version so we handle that here.
 """
 function getdeps(manifest)
-    @static if VERSION >= v"1.6.0"
+    @static if VERSION >= v"1.6.2"
         # Manifest is a struct
         return manifest.deps
     elseif VERSION >= v"1.1.0"


### PR DESCRIPTION
Ran into this when I tried running with 1.6.0. Looks like the change from dict to struct was only backported to 1.6 starting from 1.6.2, see here:

https://github.com/JuliaLang/Pkg.jl/pull/2592/files#diff-39d5f9e47d567ec5ed9f74c56cd46d75ad2d1b2752e4853eb5bb0cffa5234498L222