### PR TITLE
Port changes for 1.8 from TestEnv

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TestReports"
 uuid = "dcd651b4-b50a-5b6b-8f22-87e9f253a252"
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
I will move `TestReports` to use `TestEnv` to avoid having to do this for each new release, but for now I just want to get it working for `v1.8`