### PR TITLE
Drop support for Julia <1.6 (LTS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
-          - '1.6'
-          - '1'
+          - '1.6'  # LTS / Oldest supported version
+          - '1'    # Latest release
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 EzXML = "1"
-julia = "1"
+julia = "1.6"
 
 [extras]
 ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"

--- a/src/TestReports.jl
+++ b/src/TestReports.jl
@@ -8,8 +8,8 @@ using Test
 
 using Pkg: PackageSpec
 using Pkg.Types: Context, ensure_resolved, is_project_uuid
-using Pkg.Operations: manifest_info, manifest_resolve!, project_deps_resolve!,
-    project_rel_path, project_resolve!
+using Pkg.Operations: gen_target_project, manifest_info, manifest_resolve!,
+    project_deps_resolve!, project_rel_path, project_resolve!, sandbox, source_path
 
 using Test: AbstractTestSet, DefaultTestSet, Result, Pass, Fail, Error, Broken,
     get_testset, get_testset_depth, scrub_backtrace
@@ -17,19 +17,8 @@ using Test: AbstractTestSet, DefaultTestSet, Result, Pass, Fail, Error, Broken,
 import Test: finish, record
 
 # Version specific imports
-@static if VERSION >= v"1.4.0"
-    using Pkg.Operations: gen_target_project
-else
-    using Pkg.Operations: with_dependencies_loadable_at_toplevel
-end
-@static if VERSION >= v"1.2.0"
-    using Pkg.Operations: sandbox, source_path
-    @static if VERSION < v"1.7.0"
-        using Pkg.Operations: update_package_test!
-    end
-else
-    using Pkg.Operations: find_installed
-    using Pkg.Types: SHA1
+@static if VERSION < v"1.7.0"
+    using Pkg.Operations: update_package_test!
 end
 
 export ReportingTestSet, any_problems, report, recordproperty
@@ -45,7 +34,6 @@ const TESTREPORTS_UUID = let
     Base.UUID(toml["uuid"])
 end
 
-include("v1_compat.jl")
 include("./testsets.jl")
 include("to_xml.jl")
 include("compat_check.jl")

--- a/src/v1_compat.jl
+++ b/src/v1_compat.jl
@@ -1,9 +1,0 @@
-@static if VERSION < v"1.1.0"
-    """
-        isnothing(x)
-
-    Return `true` if `x === nothing`, and return `false` if not.
-    """
-    isnothing(::Any) = false
-    isnothing(::Nothing) = true
-end

--- a/test/reportgeneration.jl
+++ b/test/reportgeneration.jl
@@ -81,14 +81,12 @@ end
     ]
     foreach(test_package_expected_pass, test_pkgs)
 
-    # Test file project file tests, 1.2 and above
-    @static if VERSION >= v"1.2.0"
-        test_pkgs = [
-            "TestsWithProjectFile",
-            "TestsWithProjectFileWithTestDeps"
-        ]
-        foreach(test_package_expected_pass, test_pkgs)
-    end
+    # Test file project file tests
+    test_pkgs = [
+        "TestsWithProjectFile",
+        "TestsWithProjectFileWithTestDeps"
+    ]
+    foreach(test_package_expected_pass, test_pkgs)
 
     # Test arguments
     temp_pkg_dir() do tmp

--- a/test/runnerinternals.jl
+++ b/test/runnerinternals.jl
@@ -2,29 +2,6 @@ using Pkg
 using Test
 using TestReports
 
-if VERSION < v"1.2.0"
-    @testset "gettestfilepath - V1.0.5" begin
-        # Stdlibs are not tested by other functions for V1.0.5
-        stdlibname = "Dates"
-        ctx = Pkg.Types.Context()
-        pkg = Pkg.PackageSpec(stdlibname)
-        TestReports.isinstalled!(ctx, pkg)
-        delete!(ctx.env.manifest[stdlibname][1], "path")  # Remove path to force stdlib check
-        testfilepath = joinpath(abspath(joinpath(dirname(Base.find_package(stdlibname)), "..")), "test", "runtests.jl")
-        @test TestReports.gettestfilepath(ctx, pkg) == testfilepath
-
-        # PkgTestError when PkgSpec has missing info when finding path - V1.0.5 only
-        pkgname = "PassingTests"
-        Pkg.develop(Pkg.PackageSpec(path=joinpath(@__DIR__, "test_packages", pkgname)))
-        ctx = Pkg.Types.Context()
-        pkg = Pkg.PackageSpec(pkgname)
-        TestReports.isinstalled!(ctx, pkg)
-        delete!(ctx.env.manifest["PassingTests"][1], "path")
-        @test_throws TestReports.PkgTestError TestReports.gettestfilepath(ctx, pkg)
-        Pkg.rm(Pkg.PackageSpec(path=joinpath(@__DIR__, "test_packages", pkgname)))
-    end
-end
-
 @testset "showerror" begin
     @test_throws TestReports.PkgTestError throw(TestReports.PkgTestError("Test"))
     @test sprint(showerror, TestReports.PkgTestError("Error text"), "") == "Error text"
@@ -54,15 +31,13 @@ end
     test_package_expected_fail("OldTestReportsInTarget")
     test_package_expected_fail("OldTestReportsInDeps")
     test_package_expected_fail("OldDepInTarget")
-    if VERSION >= v"1.2.0"
-        test_package_expected_fail("OldTestReportsInTestDeps")
-        test_package_expected_fail("OldDepInTestDeps")
-        if VERSION >= v"1.7.0"
-            test_package_expected_fail("OldTestReportsInTestManifest_1_7") # new manifest format
-            test_package_expected_fail("OldDepInTestManifest_1_7") # new manifest format
-        else
-            test_package_expected_fail("OldTestReportsInTestManifest")
-            test_package_expected_fail("OldDepInTestManifest")
-        end
+    test_package_expected_fail("OldTestReportsInTestDeps")
+    test_package_expected_fail("OldDepInTestDeps")
+    if VERSION >= v"1.7.0"
+        test_package_expected_fail("OldTestReportsInTestManifest_1_7") # new manifest format
+        test_package_expected_fail("OldDepInTestManifest_1_7") # new manifest format
+    else
+        test_package_expected_fail("OldTestReportsInTestManifest")
+        test_package_expected_fail("OldDepInTestManifest")
     end
 end

--- a/test/to_xml.jl
+++ b/test/to_xml.jl
@@ -25,11 +25,7 @@ struct CustomException <: Exception end
         end
         err = ts.results[1].result
         _, type, _ = TestReports.get_error_info(err)
-        if VERSION < v"1.2"
-            @test type == "ErrorException" 
-        else
-            @test type == "ProcessFailedException" 
-        end
+        @test type == "ProcessFailedException"
 
         # Custom exception
         ts = @testset ReportingTestSet begin 


### PR DESCRIPTION
Updated the package to drop support for Julia version below 1.6. As Julia 1.6 is still currently the LTS we should at least still support that version. I don't require this change but it does make the code base easier to maintain.