### PR TITLE
Avoid using deepcopy `report` for internal use

### DIFF
--- a/bin/reporttests.jl
+++ b/bin/reporttests.jl
@@ -12,7 +12,7 @@ ts = @testset ReportingTestSet "" begin
 end
 
 open("testlog.xml","w") do fh
-    print(fh, report(ts))
+    print(fh, report(TestReports.flatten_results!(ts)))
 end
 exit(any_problems(ts))
 """

--- a/bin/reporttests.jl
+++ b/bin/reporttests.jl
@@ -12,6 +12,7 @@ ts = @testset ReportingTestSet "" begin
 end
 
 open("testlog.xml","w") do fh
+    # Flatten before calling `report` to avoid a `deepcopy`.
     print(fh, report(TestReports.flatten_results!(ts)))
 end
 exit(any_problems(ts))

--- a/src/runner.jl
+++ b/src/runner.jl
@@ -136,7 +136,7 @@ function gen_runner_code(testfilename, logfilename, test_args)
             include($(repr(testfilename)))
         end
 
-        write($(repr(logfilename)), report(ts))
+        write($(repr(logfilename)), report(TestReports.flatten_results!(ts)))
         any_problems(ts) && exit(TestReports.TESTS_FAILED)
         """
     return runner_code

--- a/src/runner.jl
+++ b/src/runner.jl
@@ -136,6 +136,7 @@ function gen_runner_code(testfilename, logfilename, test_args)
             include($(repr(testfilename)))
         end
 
+        # Flatten before calling `report` to avoid a `deepcopy`.
         write($(repr(logfilename)), report(TestReports.flatten_results!(ts)))
         any_problems(ts) && exit(TestReports.TESTS_FAILED)
         """


### PR DESCRIPTION
Follow up to #104. Avoids using `deepcopy` when calling `report` internally and we don't care about the original testset.

The main reason I made this PR is I found while test driving #106 that I encountered this error while executing my tests with `TestReports.test()`:
```
Test Summary:          | Pass  Total     Time
***.jl                 |  143    143  1m09.8s
ERROR: MethodError: no method matching deepcopy_internal(::Base.Threads.SpinLock)
Closest candidates are:
  deepcopy_internal(::Base.AbstractLock, ::IdDict) at deepcopy.jl:130
  deepcopy_internal(::Any, ::IdDict) at deepcopy.jl:53
  deepcopy_internal(::BigInt, ::IdDict) at gmp.jl:794
  ...
Stacktrace:
  [1] deepcopy_internal(x::Base.GenericCondition{Base.Threads.SpinLock}, stackdict::IdDict{Any, Any})
    @ Base ./deepcopy.jl:143
  [2] deepcopy_internal(x::Any, stackdict::IdDict{Any, Any})
    @ Base ./deepcopy.jl:65
  [3] deepcopy_internal(x::Any, stackdict::IdDict{Any, Any}) (repeats 3 times)
    @ Base ./deepcopy.jl:76
  [4] _deepcopy_array_t(x::Array, T::Type, stackdict::IdDict{Any, Any})
    @ Base ./deepcopy.jl:105
  [5] deepcopy_internal(x::Vector{Any}, stackdict::IdDict{Any, Any})
    @ Base ./deepcopy.jl:92
  [6] deepcopy_internal(x::Any, stackdict::IdDict{Any, Any})
    @ Base ./deepcopy.jl:65
  [7] deepcopy_internal(x::Any, stackdict::IdDict{Any, Any})
    @ Base ./deepcopy.jl:76
  [8] deepcopy_internal(x::Any, stackdict::IdDict{Any, Any})
    @ Base ./deepcopy.jl:65
  [9] _deepcopy_array_t(x::Array, T::Type, stackdict::IdDict{Any, Any})
    @ Base ./deepcopy.jl:105
 [10] deepcopy_internal(x::Vector{Any}, stackdict::IdDict{Any, Any})
    @ Base ./deepcopy.jl:92
 [11] deepcopy_internal(x::Any, stackdict::IdDict{Any, Any})
    @ Base ./deepcopy.jl:65
 [12] _deepcopy_array_t(x::Array, T::Type, stackdict::IdDict{Any, Any})
    @ Base ./deepcopy.jl:105
 [13] deepcopy_internal(x::Vector{Any}, stackdict::IdDict{Any, Any})
    @ Base ./deepcopy.jl:92
 [14] deepcopy_internal(x::Any, stackdict::IdDict{Any, Any})
    @ Base ./deepcopy.jl:65
 [15] _deepcopy_array_t(x::Array, T::Type, stackdict::IdDict{Any, Any})
    @ Base ./deepcopy.jl:105
 [16] deepcopy_internal(x::Vector{Any}, stackdict::IdDict{Any, Any})
    @ Base ./deepcopy.jl:92
 [17] deepcopy_internal(x::Any, stackdict::IdDict{Any, Any})
    @ Base ./deepcopy.jl:65
 [18] deepcopy
    @ ./deepcopy.jl:26 [inlined]
 [19] report(ts::ReportingTestSet)
    @ TestReports ~/.julia/packages/TestReports/NKFrO/src/to_xml.jl:137
 [20] top-level scope
    @ none:16
ERROR: LoadError: TestReports failed to generate the report.
See error log above.
in expression starting at /home/runner/work/_temp/ab20e520-3ff6-4bc7-8959-ea6c88189c80:4
Error: Process completed with exit code 1.
```
In looking into the problem I found this MWE on Julia 1.8.0:
```julia
using TestReports, Test

ts = @testset ReportingTestSet begin
    @test stdout !== stderr
end;

deepcopy(ts)
```
I was unable to reproduce the problem on Julia 1.8.5. 

