### PR TITLE
Runner script uses exit code from test file

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TestReports"
 uuid = "dcd651b4-b50a-5b6b-8f22-87e9f253a252"
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/bin/reporttests.jl
+++ b/bin/reporttests.jl
@@ -79,10 +79,6 @@ if abspath(PROGRAM_FILE) == @__FILE__()
     )
     cmd = TestReports.gen_command(runner_code, ``, coverage)
 
-    try
-        run(cmd)
-    catch e
-        e isa ProcessFailedException && exit(only(e.procs).exitcode)
-        rethrow()
-    end
+    p = run(ignorestatus(cmd))
+    success(p) || exit(p.exitcode)
 end

--- a/bin/reporttests.jl
+++ b/bin/reporttests.jl
@@ -80,5 +80,5 @@ if abspath(PROGRAM_FILE) == @__FILE__()
     cmd = TestReports.gen_command(runner_code, ``, coverage)
 
     p = run(ignorestatus(cmd))
-    success(p) || exit(p.exitcode)
+    exit(p.exitcode)
 end

--- a/test/reporttests_script.jl
+++ b/test/reporttests_script.jl
@@ -73,6 +73,18 @@ end
     @test !success(p)
 end
 
+@testset "use test script exit code" begin
+    mktempdir() do dir
+        exit_code = 42
+        exit_test_script = joinpath(dir, "runtests.jl")
+        write(exit_test_script, "exit($exit_code)")
+
+        p = run(ignorestatus(`$runner_cmd $exit_test_script`))
+        @test !success(p)
+        @test p.exitcode == exit_code
+    end
+end
+
 @testset "default output file" begin
     output_file = "testlog.xml"
     p = run(ignorestatus(`$runner_cmd $test_script`))


### PR DESCRIPTION
Noticed this testing gap in #113 due to using `only` which requires Julia 1.4+