### PR TITLE
Fix #121: Add REPL to weakdepends in temp Manifest

### DIFF
--- a/src/runner.jl
+++ b/src/runner.jl
@@ -98,6 +98,12 @@ function make_testreports_environment(manifest)
             )
         )
     end
+
+    if VERSION >= v"1.11.0"
+        # add REPL to Pkg weakdepends (https://github.com/JuliaTesting/TestReports.jl/issues/121#issuecomment-2413243321)
+        new_manifest["deps"]["Pkg"][1]["weakdeps"] = Dict{String,Any}("REPL" => "3fa0cd96-eef1-5676-8a61-b3b8758bbffb")
+    end
+
     testreportsenv = mktempdir()
     open(joinpath(testreportsenv, "Project.toml"), "w") do io
         Pkg.TOML.print(io, new_project)


### PR DESCRIPTION
This should fix #121 

Steps to reproduce the previous failure:

```
$ git clone https://github.com/pjaap/TestPackage.jl # simple package with a single unit test
$ julia
] activate @v1.11
] add TestReports
] activate TestPackage.jl
julia> using TestReports
juia> TestReports.test("TestPackage") # crash
```

Adding `TestReports` in the `TestPackage` environment does not create a crash.
 